### PR TITLE
Add marlin/sailfish repos

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -46,5 +46,7 @@
   <project path="kernel/samsung/universal9810" name="android_kernel_samsung_universal9810" groups="device,star2lte" remote="maruos" clone-depth="100" />
   <project path="device/samsung/universal9810-common" name="android_device_samsung_universal9810-common" groups="device,star2lte,pdk" remote="maruos" />
   <project path="device/samsung/star2lte" name="android_device_samsung_star2lte" groups="device,star2lte,pdk" remote="maruos" />
+  <project path="kernel/google/marlin" name="android_kernel_google_marlin" groups="device,marlin,sailfish" remote="maruos" clone-depth="100" />
+  <project path="device/google/marlin" name="android_device_google_marlin" groups="device,marlin,sailfish,pdk" remote="maruos" />
 
 </manifest>


### PR DESCRIPTION
Add kernel and device code for Maru on the Google Pixel(sailfish).
Because Google Pixle XL(marlin) uses the same kernel and device
repo with Google Pixel(sailfish), so we add repos for it too.